### PR TITLE
Add macOS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,24 @@ satellit
 
 ### Prerequisites
 
-- Ubuntu 20.04 or 18.04 or 16.04 LTS
 - Resolution 1920x1080
-- Partially tested on Fedora 28
+
+**Ubuntu** (20.04, 18.04, 16.04 LTS):
+```
+sudo apt-get install libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev \
+  doxygen libconfig-dev libsdl2-mixer-dev libcunit1-dev graphviz
+```
+
+**macOS** (via [Homebrew](https://brew.sh)):
+```
+brew install sdl2 sdl2_image sdl2_ttf sdl2_mixer libconfig cunit doxygen graphviz
+```
+
+**Fedora** (partially tested):
+```
+sudo yum install SDL2-devel SDL2_image-devel SDL2_ttf-devel \
+  doxygen libconfig-devel SDL2_mixer-devel CUnit-devel
+```
 
 ## Versioning
 

--- a/satellit.sh
+++ b/satellit.sh
@@ -13,6 +13,8 @@
 ##	Fedora (only development tested)
 ##		sudo yum install SDL2-devel SDL2_image-devel SDL2_ttf-devel \
 ##		doxygen libconfig-devel SDL2_mixer-devel CUnit-devel
+##	macOS (via Homebrew)
+##		brew install sdl2 sdl2_image sdl2_ttf sdl2_mixer libconfig cunit doxygen graphviz
 ##
 ##	Build Satellit;
 ##
@@ -27,7 +29,12 @@
 ##
 
 prg=$(basename $0)
-dir=$(dirname $0); dir=$(readlink -f $dir)
+dir=$(dirname $0)
+if readlink -f "$dir" > /dev/null 2>&1; then
+	dir=$(readlink -f $dir)
+else
+	dir=$(cd "$dir" && pwd -P)
+fi
 me=$dir/$prg
 tmp=/tmp/${prg}_$$
 sshopt='-q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no'

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,12 @@
 CFLAGS = -Wall -pedantic -Werror -g
 LFLAGS = `sdl2-config --libs` -lSDL2_image -lSDL2_ttf -lm -lconfig
+
+UNAME := $(shell uname)
+ifeq ($(UNAME), Darwin)
+BREW_PREFIX := $(shell brew --prefix 2>/dev/null || echo /usr/local)
+CFLAGS += -I$(BREW_PREFIX)/include
+LFLAGS += -L$(BREW_PREFIX)/lib
+endif
 PROG = satellit
 PROG_TARGET = $(addprefix $(SAT_GIT)/, $(PROG))
 CXX = gcc

--- a/src/audio/audio.c
+++ b/src/audio/audio.c
@@ -16,7 +16,7 @@
 
 #include "audio.h"
 
-SDL_AudioDeviceID * audio_init() {
+SDL_AudioDeviceID * audio_init(void) {
 
 	SDL_AudioSpec want, have;
 	SDL_AudioDeviceID *audiodev;

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -28,7 +28,7 @@
  * @return Pointer to audiodevice if passed, NULL if failed.
  *
  */
-SDL_AudioDeviceID * audio_init();
+SDL_AudioDeviceID * audio_init(void);
 
 /**
  * @brief Destroy audio device and structures.

--- a/src/generic/log.c
+++ b/src/generic/log.c
@@ -28,7 +28,7 @@ int log_init(char *log) {
 	return 0;
 }
 
-int log_destroy() {
+int log_destroy(void) {
 
 	if(fclose(logfile) != 0) {
 		return 1;

--- a/src/generic/log.h
+++ b/src/generic/log.h
@@ -47,7 +47,7 @@ int log_init(char *log);
  * @return Zero if initilization passed, 1 if failed.
  *
  */
-int log_destroy();
+int log_destroy(void);
 
 #endif
 

--- a/src/graphics/graphics.c
+++ b/src/graphics/graphics.c
@@ -102,7 +102,7 @@ void gfx_screen_destroy(SDL_Window *window, SDL_Renderer *renderer) {
 	SDL_Quit();
 }
 
-gfx_image_list *gfx_image_list_init() {
+gfx_image_list *gfx_image_list_init(void) {
 
 	gfx_image_list *imgl = calloc(1, sizeof(gfx_image_list));
 

--- a/src/graphics/graphics.c
+++ b/src/graphics/graphics.c
@@ -56,8 +56,13 @@ enum graphicsReturnCode gfx_screen_init(char *title, int *width, int *height,
 		*height = current.h;
 	}
 
+#ifdef __APPLE__
+	*window = SDL_CreateWindow(title, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
+		*width, *height, SDL_WINDOW_FULLSCREEN_DESKTOP);
+#else
 	*window = SDL_CreateWindow(title, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
 		*width, *height, SDL_WINDOW_FULLSCREEN);
+#endif
 	if (*window == NULL) {
 		return GRAPHICS_SDL;
 	}

--- a/src/graphics/graphics.h
+++ b/src/graphics/graphics.h
@@ -93,7 +93,7 @@ void gfx_screen_destroy(SDL_Window *window, SDL_Renderer *renderer);
  * @return Pointer to allocated image list
  *
  */
-gfx_image_list *gfx_image_list_init();
+gfx_image_list *gfx_image_list_init(void);
 
 /**
  * @brief Destroy an image list.

--- a/src/logic/position.c
+++ b/src/logic/position.c
@@ -16,8 +16,13 @@
 
 #include "position.h"
 
+int space_w_min = SPACE_W_MIN;
+int space_w_max = SPACE_W_MAX;
+int space_h_min = SPACE_H_MIN;
+int space_h_max = SPACE_H_MAX;
+
 enum positionReturnCode position_validate(double x, double y) {
-	if ((x >= SPACE_W_MIN && x <= SPACE_W_MAX) && (y >= SPACE_H_MIN && y <= SPACE_H_MAX)) {
+	if ((x >= space_w_min && x <= space_w_max) && (y >= space_h_min && y <= space_h_max)) {
 		return POSITION_OK;
 	}
 	return POSITION_ERR_OOB;

--- a/src/logic/position.h
+++ b/src/logic/position.h
@@ -42,6 +42,9 @@ enum positionReturnCode {
     POSITION_ERR_VEL,	/**< Faulty Velocity. */
 };
 
+/** Runtime space boundaries — set at startup based on actual screen resolution. */
+extern int space_w_min, space_w_max, space_h_min, space_h_max;
+
 /**
  * @brief Initalize and allocate position.
  * @param x Initial position in X.

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -56,6 +56,12 @@ int main(int argc, char *argv[])
 		exit(1);
 	}
 
+	/* Set space boundaries based on actual screen resolution (5% margin) */
+	space_w_min = gh->res_w * 0.05;
+	space_w_max = gh->res_w * 0.95;
+	space_h_min = gh->res_h * 0.05;
+	space_h_max = gh->res_h * 0.95;
+
 	/* Initialize images */
 	gh->imgl = gfx_image_list_init();
 	if (gh->imgl == NULL) {

--- a/src/main/main.h
+++ b/src/main/main.h
@@ -20,6 +20,7 @@
  */
 
 #include "common.h"
+#include "position.h"
 #include "rocket.h"
 #include "planet.h"
 #include "moon.h"

--- a/src/objects/object.c
+++ b/src/objects/object.c
@@ -28,7 +28,7 @@ const char* object_enum2str(enum objectReturnCode ret) {
 	}
 }
 
-object_list * object_list_init() {
+object_list * object_list_init(void) {
 	object_list *objl;
 	objl = calloc(1, sizeof(object_list));
 	objl->n_objs = 0;

--- a/test/unittest/Makefile
+++ b/test/unittest/Makefile
@@ -1,5 +1,12 @@
 CFLAGS = -Wall -pedantic -Werror -g
 LFLAGS = `sdl2-config --libs` -lSDL2_image -lSDL2_ttf -lm -lconfig -lcunit
+
+UNAME := $(shell uname)
+ifeq ($(UNAME), Darwin)
+BREW_PREFIX := $(shell brew --prefix 2>/dev/null || echo /usr/local)
+CFLAGS += -I$(BREW_PREFIX)/include
+LFLAGS += -L$(BREW_PREFIX)/lib
+endif
 PROG = utest
 PROG_TARGET = $(addprefix $(SAT_GIT)/, $(PROG))
 CXX = gcc

--- a/test/unittest/unittest.c
+++ b/test/unittest/unittest.c
@@ -299,7 +299,7 @@ void test_log(void) {
 
 }
 
-int main()
+int main(void)
 {
 	CU_pSuite pSuite = NULL;
 	unsigned int ret;


### PR DESCRIPTION
## Summary

End-to-end macOS support — the game now builds and runs on macOS via Homebrew.

### Build fixes
- Fix `readlink -f` incompatibility in `satellit.sh` — macOS does not support the `-f` flag; replaced with a portable `cd && pwd -P` fallback
- Add macOS detection to `src/Makefile` and `test/unittest/Makefile` via `uname`; appends Homebrew prefix to `CFLAGS`/`LFLAGS` so SDL2, libconfig, and CUnit are found
- Fix strict prototype errors (`-Wstrict-prototypes -Werror`) for Apple Clang by adding explicit `void` to empty parameter lists in `audio_init`, `log_destroy`, `gfx_image_list_init`, and `object_list_init`

### Runtime fixes
- Use `SDL_WINDOW_FULLSCREEN_DESKTOP` on macOS instead of exclusive fullscreen (`SDL_WINDOW_FULLSCREEN`), which caused the window to flash and immediately disappear
- Make position space boundaries resolution-aware: previously hardcoded to 100px margins for 1920×1080, which caused object placement to fail on narrower displays (e.g. 1512px wide MacBook); now computed as 5% of actual screen size at startup

### Documentation
- Add macOS prerequisites and `brew install` instructions to `README.md` and `satellit.sh` header comments

## Install prerequisites (macOS)

```
brew install sdl2 sdl2_image sdl2_ttf sdl2_mixer libconfig cunit doxygen graphviz
```

## Test plan

- [x] `source envsettings && satellit build` succeeds on macOS
- [x] `satellit start` launches and runs the game on macOS
- [x] Existing Ubuntu build is unaffected
- [x] `satellit utest_build && satellit utest_start` passes on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)