### PR TITLE
src: Remove unnecessary platform-specific branches

### DIFF
--- a/satellit.sh
+++ b/satellit.sh
@@ -29,12 +29,7 @@
 ##
 
 prg=$(basename $0)
-dir=$(dirname $0)
-if readlink -f "$dir" > /dev/null 2>&1; then
-	dir=$(readlink -f $dir)
-else
-	dir=$(cd "$dir" && pwd -P)
-fi
+dir=$(cd "$(dirname $0)" && pwd -P)
 me=$dir/$prg
 tmp=/tmp/${prg}_$$
 sshopt='-q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no'

--- a/src/graphics/graphics.c
+++ b/src/graphics/graphics.c
@@ -56,13 +56,8 @@ enum graphicsReturnCode gfx_screen_init(char *title, int *width, int *height,
 		*height = current.h;
 	}
 
-#ifdef __APPLE__
 	*window = SDL_CreateWindow(title, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
 		*width, *height, SDL_WINDOW_FULLSCREEN_DESKTOP);
-#else
-	*window = SDL_CreateWindow(title, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
-		*width, *height, SDL_WINDOW_FULLSCREEN);
-#endif
 	if (*window == NULL) {
 		return GRAPHICS_SDL;
 	}


### PR DESCRIPTION
## Summary
- Replace `#ifdef __APPLE__` in `graphics.c` with `SDL_WINDOW_FULLSCREEN_DESKTOP` unconditionally — this flag works on both Linux and macOS
- Replace the `readlink -f` / fallback branching in `satellit.sh` with a single portable `cd && pwd -P` that works on both platforms

## Test plan
- [x] `./satellit.sh build` compiles cleanly on macOS
- [x] `./satellit.sh utest_build && ./satellit.sh utest_start` — all 11 tests pass
- [x] `./satellit.sh start` — verify game starts and runs correctly on macOS
- [x] `./satellit.sh start` — verify game starts and runs correctly on Ubuntu

🤖 Generated with [Claude Code](https://claude.com/claude-code)